### PR TITLE
Logging client errors

### DIFF
--- a/flask_rage.py
+++ b/flask_rage.py
@@ -72,11 +72,12 @@ class FlaskRage:
         :param response: flask.Response
         :return: response
         """
-        if response.status_code >= 400:
+        if response.status_code >= 500:
             return response
 
+        log_fn = self.logger.info if response.status_code < 400 else self.logger.error
         message, extra = self._parse(request, response)
-        self.logger.info(message, extra=extra)
+        log_fn(message, extra=extra)
         return response
 
     def log_exception(self, exception):

--- a/test_flask_rage.py
+++ b/test_flask_rage.py
@@ -72,12 +72,22 @@ class TestFlaskRage(unittest.TestCase):
             resp = Response(status=200)
             self.rage.log_request(resp)
         logger.info.assert_called()
+        logger.error.assert_not_called()
+
+    def test_logs_error_for_request_with_code_gteq_400(self):
+        logger = Mock()
+        self.rage.logger = logger
+        with self.app.test_request_context('/test'):
+            resp = Response(status=400)
+            self.rage.log_request(resp)
+        logger.info.assert_not_called()
+        logger.error.assert_called_once()
 
     def test_does_not_log_request_for_exceptions(self):
         logger = Mock()
         self.rage.logger = logger
         with self.app.test_request_context('/test'):
-            resp = Response(status=403)
+            resp = Response(status=500)
             self.rage.log_request(resp)
         logger.info.assert_not_called()
 


### PR DESCRIPTION
When returning 401 (e.g. with basic authentication) through `make_response` - such thing was neither logged as a request, nor as an exception...

Same for 400 (bad request)